### PR TITLE
Changed set permissions task from ansible files module to native chmod to increase speed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,12 +45,11 @@
   when: aem_cms_remove_download
 
 - name: Set permissions.
-  file:
-    path: "{{ aem_cms_home }}"
-    state: directory
-    owner: "{{ aem_cms_user }}"
-    group: "{{ aem_cms_group }}"
-    recurse: true
+  command: "chown -c -R {{aem_cms_user}}:{{ aem_cms_group }} '{{ aem_cms_home }}'"
+  args:
+    warn: false
+  register: permissions_result
+  changed_when: "permissions_result.stdout != \"\""
 
 - name: Setup AEM systemd unit.
   include: systemd.yml


### PR DESCRIPTION
During deployment of our projects the set-permissions task sometimes take up to more than 6 minutes.
This was somehow depended on the overall system load and capacity but using the native chmod command for setting permissions may speed up the whole process. 

Background: The ansible file module handles each file separately to generate a change list.

I did a performance comparison between chmod and ansible file.
Each deployment ran 5 times to get a average

file: 1,2322 seconds
chmod: 0,3186 seconds (0,1521 seconds just the task, without ansible overhead)
Chmod duration is only 25% compared to the ansible file module

I also measured on a second system:
file: 5,732 seconds
chmod: 1,041 seconds
Chmod duration is only 18% compared to the ansible file module

Since we currently do not depend on the changeset of the set permissions task we should think about changing to chmod.