### PR TITLE
Switch to new synchronous stop mode, optimized stop call on not start…

### DIFF
--- a/templates/aem.init.j2
+++ b/templates/aem.init.j2
@@ -21,7 +21,7 @@ AEM_USER={{ aem_cms_user }}
 ########
 BIN=${AEM_ROOT}/crx-quickstart/bin
 START=${BIN}/start
-STOP=${BIN}/stop
+STOP="${BIN}/stop --sync"
 STATUS="${BIN}/status"
 
 aem_start() {
@@ -30,27 +30,18 @@ aem_start() {
   else
     log_daemon_msg "Starting $DESC" "$SCRIPT_NAME"
     su - ${AEM_USER} ${START} > /dev/null
-    touch /var/lock/$SCRIPT_NAME
     log_end_msg 0
   fi
 }
 
 aem_stop() {
-  log_daemon_msg "Stopping $DESC" "$SCRIPT_NAME"
   if $0 status > /dev/null ; then
+    log_daemon_msg "Stopping $DESC" "$SCRIPT_NAME"
     su - ${AEM_USER} -c "bash ${STOP}" > /dev/null
+    log_end_msg 0
+  else
+    log_success_msg "$SCRIPT_NAME not started"
   fi
-  rm -f /var/lock/$SCRIPT_NAME
-  log_end_msg 0
-}
-
-aem_shutdown_wait() {
-  log_daemon_msg "Waiting for shutdown to complete"
-  while $0 status > /dev/null 2>&1; do
-    log_progress_msg "."
-    sleep 5
-  done
-  log_end_msg 0
 }
 
 case "$1" in
@@ -65,7 +56,6 @@ su - ${AEM_USER} ${STATUS}
 ;;
 restart)
 aem_stop
-aem_shutdown_wait
 aem_start
 ;;
 *)

--- a/templates/aem.service.j2
+++ b/templates/aem.service.j2
@@ -8,11 +8,10 @@ Requires=network.target
 [Service]
 Type=forking
 ExecStart={{ aem_cms_home }}/crx-quickstart/bin/start
-ExecStop={{ aem_cms_home }}/crx-quickstart/bin/stop
+ExecStop={{ aem_cms_home }}/crx-quickstart/bin/stop --sync
 PIDFile={{ aem_cms_home }}/crx-quickstart/conf/cq.pid
 User={{ aem_cms_user }}
 LimitNOFILE={{ aem_cms_limit_nofile }}
-KillMode=none
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…ed instance, removed not used lock file.

This PR depends on https://github.com/wcm-io-devops/conga-aem-definitions/pull/22

This PR will call the AEM stop script in the new sync mode.
This mode ensures, that the AEM instance is shutdown completely (or killed by timeout).