### PR TITLE
Add aem_cms_dependency_java variable in order to disable java installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Fileglob(s) of files to copy to the `crx-quickstart/install` directory during se
 
 Sets the `nofile` limit for the AEM user.
 
+    aem_cms_dependency_java: true
+
+Controls if Java is installed by using [williamyeh.oracle-java](https://galaxy.ansible.com/williamyeh/oracle-java/) role for installing Java.
+
+
 ## Dependencies
 
 This role depends on the [williamyeh.oracle-java](https://galaxy.ansible.com/williamyeh/oracle-java/) role for installing Java.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Sets the `nofile` limit for the AEM user.
 
     aem_cms_dependency_java: true
 
-Controls if Java is installed by using [williamyeh.oracle-java](https://galaxy.ansible.com/williamyeh/oracle-java/) role for installing Java.
+Controls if Java is installed by using [srsp.oracle-java](https://galaxy.ansible.com/srsp/oracle-java/) role for installing Java.
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,3 +52,6 @@ aem_cms_remove_download: false
 
 # nofile limit (defaults to Adobe recommendation)
 aem_cms_limit_nofile: 20000
+
+# controls if the java dependency is enabled/disabled
+aem_cms_dependency_java: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,4 +26,9 @@ galaxy_info:
     - wcmio
 
 dependencies:
-  - { role: williamyeh.oracle-java, java_remove_download: false, tags: "dev.java" }
+  - {
+      role: williamyeh.oracle-java,
+      java_remove_download: false,
+      tags: "dev.java",
+      when: aem_cms_dependency_java == true
+    }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,9 +27,9 @@ galaxy_info:
     - wcmio
 
 dependencies:
-  - { 
-      role: srsp.oracle-java,
-      java_remove_download: false,
-      tags: "dev.java",
-      when: aem_cms_dependency_java == true
-    }
+- {
+    role: srsp.oracle-java,
+    java_remove_download: false,
+    tags: "dev.java",
+    when: aem_cms_dependency_java == true
+  }


### PR DESCRIPTION
We need the possibility to skip the java installation in environments were java is already installed.