### PR TITLE
Add AEM in-place-upgrade functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   # run against latest version
   - ANSIBLE_VERSION=latest
   # run against minimal required version
-  - ANSIBLE_VERSION=2.2.*
+  - ANSIBLE_VERSION=2.4.*
 
 # Use the new container infrastructure
 sudo: false

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ Sets the `nofile` limit for the AEM user.
 
 Controls if Java is installed by using [srsp.oracle-java](https://galaxy.ansible.com/srsp/oracle-java/) role for installing Java.
 
+    aem_cms_in_place_upgrade: false
+
+Enables / disables in-place-upgrade.
+
+:exclamation: Warnings
+* Use the in place upgrade functionality with care and test it in a
+  staging environment before applying it to production!
+* Do not use this mechanism when a content repository migration is
+  necessary!
+* Do not use this mechanism when upgrading from AEM 6.2 to AEM 6.3+
+
+```
+aem_cms_in_place_upgrade_paths:
+  "6.3.0":
+    - "6.4.0"
+```
+
+Format:
+
+    "from_version":
+        - "to_version" # list of versions that an upgrade is allowed for
+
+Specifies from and to versions which are supported by the
+in-place-upgrade mechanism.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,14 @@ aem_cms_limit_nofile: 20000
 
 # controls if the java dependency is enabled/disabled
 aem_cms_dependency_java: true
+
+# Enables / disables in-place-upgrade
+aem_cms_in_place_upgrade: false
+
+# Specifies from and to versions which are supported for an in-place-upgrade
+aem_cms_in_place_upgrade_paths:
+  "6.3.0":
+    - "6.4.0"
+# "from_version":
+#    - "to_version" # list of versions that an upgrade is allowed for
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
 
   platforms:
   - name: Ubuntu

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -1,7 +1,12 @@
+- name: "in_place_upgrade : set fact for existing quickstarts."
+  set_fact:
+    aem_cms_in_place_upgrade_existing_quickstarts:  "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
+
 # get version numbers from all jar files found
 - name: "in_place_upgrade : detect version to upgrade from."
   set_fact:
-     aem_cms_in_place_upgrade_existing_version: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | map('regex_replace', '^.*cq-quickstart-(.+)-standalone-quickstart.jar$', '\\1') | list | sort | reverse | list | first}}"
+
+     aem_cms_in_place_upgrade_existing_version: "{{ aem_cms_in_place_upgrade_existing_quickstarts | map('regex_replace', '^.*cq-quickstart-(.+)-standalone-quickstart.jar$', '\\1') | list | sort | reverse | list | first}}"
 
 # safe gate which only allows upgrades when allowed
 - name: "in_place_upgrade : fail when upgrade is not allowed."
@@ -46,7 +51,7 @@
     owner: "{{ aem_cms_user }}"
     group: "{{ aem_cms_group }}"
     remote_src: True
-  with_items: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
+  with_items: "{{ aem_cms_in_place_upgrade_existing_quickstarts }}"
 
 - name: "in_place_upgrade : delete old quickstart file(s)."
   file:
@@ -54,4 +59,4 @@
     owner: "{{ aem_cms_user }}"
     group: "{{ aem_cms_group }}"
     state: absent
-  with_items: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
+  with_items: "{{ aem_cms_in_place_upgrade_existing_quickstarts }}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -1,11 +1,6 @@
-- name: "in_place_upgrade : set fact for existing quickstarts."
-  set_fact:
-    aem_cms_in_place_upgrade_existing_quickstarts:  "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
-
 # get version numbers from all jar files found
 - name: "in_place_upgrade : detect version to upgrade from."
   set_fact:
-
      aem_cms_in_place_upgrade_existing_version: "{{ aem_cms_in_place_upgrade_existing_quickstarts | map('regex_replace', '^.*cq-quickstart-(.+)-standalone-quickstart.jar$', '\\1') | list | sort | reverse | list | first}}"
 
 # safe gate which only allows upgrades when allowed

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -1,0 +1,44 @@
+# get version numbers from all jar files found
+- name: "in_place_upgrade : detect version to upgrade from."
+  set_fact:
+     aem_cms_in_place_upgrade_existing_version: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | map('regex_replace', '^.*cq-quickstart-(.+)-standalone-quickstart.jar$', '\\1') | list | sort | reverse | list | first}}"
+
+# safe gate which only allows upgrades when allowed
+- name: "in_place_upgrade : fail when upgrade is not allowed."
+  fail:
+    msg:
+      - "In place upgrade is not allowed, 'aem_cms_in_place_upgrade' is set to '{{ aem_cms_in_place_upgrade }}'"
+      - "existing version: '{{ aem_cms_in_place_upgrade_existing_version }}'"
+      - "version to deploy: '{{ aem_cms_version }}'"
+  when: aem_cms_in_place_upgrade != true
+
+# check if upgrading is allowed based on existing and new version
+- name: "in_place_upgrade : fail when upgrade path from '{{ aem_cms_in_place_upgrade_existing_version }}' to '{{ aem_cms_version }}' is not allowed."
+  fail:
+    msg: "Upgrade from {{ aem_cms_in_place_upgrade_existing_version }} to {{ aem_cms_version }} is not allowed."
+  when: aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version] is not defined or
+        aem_cms_version not in aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version]
+
+# ensure instance is stopped before renaming the jars
+- name: "in_place_upgrade : stopping existing instance for upgrade"
+  service:
+    name: "{{ aem_cms_service_name }}"
+    state: stopped
+
+# rename old quickstart jars to *.jar.bak because default start script will use first jar found in the app folder
+- name: "in_place_upgrade : create a backup of existing quickstart(s)."
+  copy:
+    src: "{{ item }}"
+    dest: "{{ item }}.bak"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"
+    remote_src: True
+  with_items: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
+
+- name: "in_place_upgrade : Delete old quickstart file(s)."
+  file:
+    path: "{{ item }}"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"
+    state: absent
+  with_items: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -1,4 +1,4 @@
-# get version numbers from all jar files found
+# get the latest version of all the existing jar files
 - name: "in_place_upgrade : detect version to upgrade from."
   set_fact:
      aem_cms_in_place_upgrade_existing_version: "{{ aem_cms_in_place_upgrade_existing_quickstarts | map('regex_replace', '^.*cq-quickstart-(.+)-standalone-quickstart.jar$', '\\1') | list | sort | reverse | list | first}}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -20,7 +20,7 @@
         aem_cms_version not in aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version]
 
 # ensure instance is stopped before renaming the jars
-- name: "in_place_upgrade : stopping existing instance for upgrade"
+- name: "in_place_upgrade : stopping existing instance for upgrade."
   service:
     name: "{{ aem_cms_service_name }}"
     state: stopped
@@ -35,7 +35,7 @@
     remote_src: True
   with_items: "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
 
-- name: "in_place_upgrade : Delete old quickstart file(s)."
+- name: "in_place_upgrade : delete old quickstart file(s)."
   file:
     path: "{{ item }}"
     owner: "{{ aem_cms_user }}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -36,16 +36,6 @@
 
 # rename old quickstart jars to *.jar.bak because default start script will use first jar found in the app folder
 - name: "in_place_upgrade : create a backup of existing quickstart(s)."
-  copy:
-    src: "{{ item }}"
-    dest: "{{ item }}.bak"
-    owner: "{{ aem_cms_user }}"
-    group: "{{ aem_cms_group }}"
-    remote_src: True
-  with_items: "{{ aem_cms_in_place_upgrade_existing_quickstarts }}"
-
-- name: "in_place_upgrade : delete old quickstart file(s)."
-  file:
-    path: "{{ item }}"
-    state: absent
+  command: "mv {{ item }} {{ item }}.bak"
+  changed_when: true
   with_items: "{{ aem_cms_in_place_upgrade_existing_quickstarts }}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -52,7 +52,5 @@
 - name: "in_place_upgrade : delete old quickstart file(s)."
   file:
     path: "{{ item }}"
-    owner: "{{ aem_cms_user }}"
-    group: "{{ aem_cms_group }}"
     state: absent
   with_items: "{{ aem_cms_in_place_upgrade_existing_quickstarts }}"

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -12,6 +12,15 @@
       - "version to deploy: '{{ aem_cms_version }}'"
   when: aem_cms_in_place_upgrade != true
 
+# fail on downgrade
+- name: "in_place_upgrade : fail on downgrade."
+  fail:
+    msg:
+    - "Downgrading is not allowed/supported!"
+    - "existing version: '{{ aem_cms_in_place_upgrade_existing_version }}'"
+    - "version to deploy: '{{ aem_cms_version }}'"
+  when: aem_cms_version | regex_replace('\\D','') | int < aem_cms_in_place_upgrade_existing_version | regex_replace('\\D','') | int
+
 # check if upgrading is allowed based on existing and new version
 - name: "in_place_upgrade : fail when upgrade path from '{{ aem_cms_in_place_upgrade_existing_version }}' to '{{ aem_cms_version }}' is not allowed."
   fail:

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -24,7 +24,7 @@
     - "Downgrading is not allowed/supported!"
     - "existing version: '{{ aem_cms_in_place_upgrade_existing_version }}'"
     - "version to deploy: '{{ aem_cms_version }}'"
-  when: aem_cms_version | regex_replace('\\D','') | int < aem_cms_in_place_upgrade_existing_version | regex_replace('\\D','') | int
+  when: aem_cms_version is version_compare(aem_cms_in_place_upgrade_existing_version, '<')
 
 # check if upgrading is allowed based on existing and new version
 - name: "in_place_upgrade : fail when upgrade path from '{{ aem_cms_in_place_upgrade_existing_version }}' to '{{ aem_cms_version }}' is not allowed."

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -33,10 +33,6 @@
   when: aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version] is not defined or
         aem_cms_version not in aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version]
 
-- name: "Fail: do not continue"
-  fail:
-    msg: do not continue
-
 # ensure instance is stopped before renaming the jars
 - name: "in_place_upgrade : stopping existing instance for upgrade."
   service:

--- a/tasks/in_place_upgrade.yml
+++ b/tasks/in_place_upgrade.yml
@@ -10,7 +10,7 @@
       - "In place upgrade is not allowed, 'aem_cms_in_place_upgrade' is set to '{{ aem_cms_in_place_upgrade }}'"
       - "existing version: '{{ aem_cms_in_place_upgrade_existing_version }}'"
       - "version to deploy: '{{ aem_cms_version }}'"
-  when: aem_cms_in_place_upgrade != true
+  when: not aem_cms_in_place_upgrade
 
 # fail on downgrade
 - name: "in_place_upgrade : fail on downgrade."
@@ -27,6 +27,10 @@
     msg: "Upgrade from {{ aem_cms_in_place_upgrade_existing_version }} to {{ aem_cms_version }} is not allowed."
   when: aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version] is not defined or
         aem_cms_version not in aem_cms_in_place_upgrade_paths[aem_cms_in_place_upgrade_existing_version]
+
+- name: "Fail: do not continue"
+  fail:
+    msg: do not continue
 
 # ensure instance is stopped before renaming the jars
 - name: "in_place_upgrade : stopping existing instance for upgrade."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,10 +43,14 @@
       - "cq-quickstart-*-standalone-quickstart.jar"
   register: aem_cms_existing_quickstarts
 
+- name: "Set fact with existing quickstart paths."
+  set_fact:
+    aem_cms_in_place_upgrade_existing_quickstarts:  "{{ aem_cms_existing_quickstarts.files | map(attribute='path') | list }}"
+
 - name: Include tasks for in-place-upgrade when necessary.
   include_tasks: in_place_upgrade.yml
   # only perform in place upgrade when no jar containing aem_cms_version is present
-  when: aem_cms_existing_quickstarts.files | map(attribute='path') | map('basename') | list | select('search', aem_cms_version) | list | length == 0
+  when: aem_cms_in_place_upgrade_existing_quickstarts | map('basename') | list | select('search', aem_cms_version) | list | length == 0
 
 - name: Unpack AEM.
   shell: "su {{ aem_cms_user }} -l -c 'java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,18 @@
         (aem_cms_quickstart_sha1 is defined and
         (aem_cms_quickstart_sha1 | lower) != aem_cms_quickstart_file.stat.checksum)
 
+- name: "Check for existing AEM installation with versions different than {{ aem_cms_version }}."
+  find:
+    paths: "{{ aem_cms_home }}/crx-quickstart/app/"
+    patterns:
+      - "cq-quickstart-*-standalone-quickstart.jar"
+  register: aem_cms_existing_quickstarts
+
+- name: Include tasks for in-place-upgrade when necessary.
+  include_tasks: in_place_upgrade.yml
+  # only perform in place upgrade when no jar containing aem_cms_version is present
+  when: aem_cms_existing_quickstarts.files | map(attribute='path') | map('basename') | list | select('search', aem_cms_version) | list | length == 0
+
 - name: Unpack AEM.
   shell: "su {{ aem_cms_user }} -l -c 'java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}'"
   args:


### PR DESCRIPTION
These changes add the AEM in-place-upgrade functionality.

When a different version is detected the role checks if 
* upgrading is allowed in general (`aem_cms_in_place_upgrade`)
* the version is newer than the deployed one (since downgrade is not supported at all)
* the upgrade path is supported (`aem_cms_in_place_upgrade_paths`)

When all checks are positive the service is stopped and the old quickstart jar is renamed to *.jar.bak since the default start script is using the first jar found in the apps folder.

After that change the role proceeds as normal (unpacking quickstart etc.)