### PR TITLE
Fix permissions during downloading AEM quickstart

### DIFF
--- a/tasks/download/file.yml
+++ b/tasks/download/file.yml
@@ -3,3 +3,4 @@
   copy:
     src: "{{ aem_cms_quickstart_name }}"
     dest: "{{ aem_cms_download_path }}"
+    mode: "o+r"

--- a/tasks/download/file.yml
+++ b/tasks/download/file.yml
@@ -3,4 +3,5 @@
   copy:
     src: "{{ aem_cms_quickstart_name }}"
     dest: "{{ aem_cms_download_path }}"
-    mode: "o+r"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"

--- a/tasks/download/maven_repository.yml
+++ b/tasks/download/maven_repository.yml
@@ -14,5 +14,6 @@
     username: "{{ aem_cms_maven_repository_username | default(omit) }}"
     password: "{{ aem_cms_maven_repository_password | default(omit) }}"
     version: "{{ item.version | default(aem_cms_version_short) }}"
-    mode: "o+r"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"
   with_items: "{{ aem_cms_maven_repository_coordinates }}"

--- a/tasks/download/maven_repository.yml
+++ b/tasks/download/maven_repository.yml
@@ -14,4 +14,5 @@
     username: "{{ aem_cms_maven_repository_username | default(omit) }}"
     password: "{{ aem_cms_maven_repository_password | default(omit) }}"
     version: "{{ item.version | default(aem_cms_version_short) }}"
+    mode: "o+r"
   with_items: "{{ aem_cms_maven_repository_coordinates }}"

--- a/tasks/download/package.yml
+++ b/tasks/download/package.yml
@@ -8,6 +8,8 @@
     src: "{{ aem_cms_package_home }}/{{ aem_cms_quickstart_name }}"
     dest: "{{ aem_cms_download_path }}"
     remote_src: True
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"
 
 - name: Remove AEM package.
   package:

--- a/tasks/download/s3.yml
+++ b/tasks/download/s3.yml
@@ -20,3 +20,9 @@
     mode: get
     aws_access_key: "{{ aem_cms_s3_access_key | default(omit) }}"
     aws_secret_key: "{{ aem_cms_s3_secret_key | default(omit) }}"
+
+- name: Set user and group for downloaded AEM artifact.
+  file:
+    path: "{{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }}"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"

--- a/tasks/download/url.yml
+++ b/tasks/download/url.yml
@@ -11,3 +11,4 @@
     url_username: "{{ aem_cms_url_username | default(omit) }}"
     url_password: "{{ aem_cms_url_password | default(omit) }}"
     checksum: "{{ _aem_cms_quickstart_checksum | default(omit) }}"
+    mode: "o+r"

--- a/tasks/download/url.yml
+++ b/tasks/download/url.yml
@@ -11,4 +11,5 @@
     url_username: "{{ aem_cms_url_username | default(omit) }}"
     url_password: "{{ aem_cms_url_password | default(omit) }}"
     checksum: "{{ _aem_cms_quickstart_checksum | default(omit) }}"
-    mode: "o+r"
+    owner: "{{ aem_cms_user }}"
+    group: "{{ aem_cms_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,10 +37,12 @@
         (aem_cms_quickstart_sha1 | lower) != aem_cms_quickstart_file.stat.checksum)
 
 - name: Unpack AEM.
-  shell: "su {{ aem_cms_user }} -l -c 'java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}'"
+  shell: "java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}"
   args:
     creates: "{{ aem_cms_home }}/crx-quickstart/app/cq-quickstart-{{ aem_cms_version }}-standalone-quickstart.jar"
     warn: false
+  become: yes
+  become_user: "{{ aem_cms_user }}"
   tags:
     - skip_ansible_lint
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,12 +37,10 @@
         (aem_cms_quickstart_sha1 | lower) != aem_cms_quickstart_file.stat.checksum)
 
 - name: Unpack AEM.
-  shell: "java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}"
+  shell: "su {{ aem_cms_user }} -l -c 'java -jar {{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }} -unpack -b {{ aem_cms_home }}'"
   args:
     creates: "{{ aem_cms_home }}/crx-quickstart/app/cq-quickstart-{{ aem_cms_version }}-standalone-quickstart.jar"
     warn: false
-  become: yes
-  become_user: "{{ aem_cms_user }}"
   tags:
     - skip_ansible_lint
 


### PR DESCRIPTION
I noticed some CI tasks failing because the default rights changed on the machines.
The quickstart was downloaded as root and the downloaded file only hat 0600 permissions.

Because the unpacking is done using the `aem_cms_user` the unpack failed since the read permissions were missing.

This PR fixes the issue.