### PR TITLE
Remove latest state from pip installation due to ansible-lint warnings

### DIFF
--- a/tasks/download/s3.yml
+++ b/tasks/download/s3.yml
@@ -6,9 +6,6 @@
 - name: Install pip.
   easy_install:
     name: pip
-    state: latest
-  tags:
-    - skip_ansible_lint
 
 - name: Install boto3 dependency.
   pip:


### PR DESCRIPTION
@interatom ansible lint started to complain about the `state: latest`.
I added a ignore tag as a quick fix but we should fix the cause of this issue.

Do you think is is safe to simply remove the state property?