### PR TITLE
Feature/rename s3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This role installs Adobe Experience Manager (AEM) 6.x on Debian/Ubuntu or RHEL/C
 
 ## Requirements
 
-This role requires Ansible 2.2 or higher and works with AEM 6.1 or higher. Also required are an AEM quickstart JAR file and a valid AEM license file. The `license.properties` files needs be made accessible to the role, normally by copying it into the `files` folder in the playbook directory. The `AEM_*_Quickstart.jar` can be supplied in the same way or retrieved from a Maven/RPM/APT repository, an HTTP URL or a S3 bucket (see below).
+This role requires Ansible 2.4 or higher and works with AEM 6.1 or higher. Also required are an AEM quickstart JAR file and a valid AEM license file. The `license.properties` files needs be made accessible to the role, normally by copying it into the `files` folder in the playbook directory. The `AEM_*_Quickstart.jar` can be supplied in the same way or retrieved from a Maven/RPM/APT repository, an HTTP URL or a S3 bucket (see below).
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.6
+  min_ansible_version: 2.4
 
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.6
 
   platforms:
   - name: Ubuntu

--- a/tasks/download/s3.yml
+++ b/tasks/download/s3.yml
@@ -12,7 +12,7 @@
     name: boto3
 
 - name: Download AEM artifact from S3.
-  s3:
+  aws_s3:
     bucket: "{{ aem_cms_s3_bucket }}"
     object: "{{ aem_cms_s3_object }}"
     dest: "{{ aem_cms_download_path }}/{{ aem_cms_quickstart_name }}"


### PR DESCRIPTION
Renamed s3 module to aws_s3. the module has been renamed since ansible 2.6