### PR TITLE
Add aem_cms_license_file variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This role installs Adobe Experience Manager (AEM) 6.x on Debian/Ubuntu or RHEL/C
 
 ## Requirements
 
-This role requires Ansible 2.7 or higher and works with AEM 6.1 or higher. Also required are an AEM quickstart JAR file and a valid AEM license file. The `license.properties` files needs be made accessible to the role, normally by copying it into the `files` folder in the playbook directory. The `AEM_*_Quickstart.jar` can be supplied in the same way or retrieved from a Maven/RPM/APT repository, an HTTP URL or a S3 bucket (see below).
+This role requires Ansible 2.7 or higher and works with AEM 6.1 or higher. Also required are an AEM quickstart JAR file and a valid AEM license file. The `license.properties` files needs be made accessible to the role, normally by copying it into the `files` folder in the playbook directory. You can also use another license file and reference it by the `aem_cms_license_file` variable. The `AEM_*_Quickstart.jar` can be supplied in the same way or retrieved from a Maven/RPM/APT repository, an HTTP URL or a S3 bucket (see below).
 
 ## Role Variables
 
@@ -130,6 +130,10 @@ specify a custom template.
     aem_cms_stop_sync_path: "{{ aem_cms_home }}/crx-quickstart/bin/stop-sync.sh"
 
 Destination path of the synchronous stop script on the instance.
+
+    aem_cms_license_file: license.properties
+
+Name of the AEM license file.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,3 +82,6 @@ aem_cms_stop_sync_template: "stop-sync.sh.j2"
 
 # Destination path of the synchronous stop script on the instance
 aem_cms_stop_sync_path: "{{ aem_cms_home }}/crx-quickstart/bin/stop-sync.sh"
+
+# File name of the AEM license file
+aem_cms_license_file: license.properties

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: Create AEM license.
   copy:
-    src: license.properties
+    src: "{{ aem_cms_license_file }}"
     dest: "{{ aem_cms_home }}/license.properties"
     owner: "{{ aem_cms_user }}"
     group: "{{ aem_cms_group }}"


### PR DESCRIPTION
In projects where you might have more than one license file, this allows for explicitly using one of them.